### PR TITLE
[FEAT] #35 - 마이페이지  axios 연결

### DIFF
--- a/src/components/fragments/AppHeader.vue
+++ b/src/components/fragments/AppHeader.vue
@@ -4,7 +4,7 @@
             <div class="logo">Questory</div>
             <nav class="nav-menu">
                 <template v-if="isLoggedIn">
-                    <a href="/profile" class="nav-link">마이페이지</a>
+                    <a href="/myPage" class="nav-link">마이페이지</a>
                     <a href="#" class="nav-link" @click.prevent="logout">로그아웃</a>
                 </template>
                 <template v-else>

--- a/src/router/authRoutes.js
+++ b/src/router/authRoutes.js
@@ -20,6 +20,11 @@ export default [
         component: () => import("@/views/auth/EditProfilePage.vue"),
     },
     {
+        path: "/edit-password",
+        name: "edit-password",
+        component: () => import("@/views/auth/EditPasswordPage.vue"),
+    },
+    {
         path: "/mypage",
         name: "mypage",
         component: () => import("@/views/auth/MypagePage.vue"),

--- a/src/views/auth/EditPasswordPage.vue
+++ b/src/views/auth/EditPasswordPage.vue
@@ -1,0 +1,222 @@
+<template>
+    <div class="edit-password-page">
+        <div class="content">
+            <h2 class="page-title">비밀번호 변경</h2>
+            <form @submit.prevent="changePassword" class="edit-form">
+                <div class="form-group">
+                    <label for="newPassword">새 비밀번호</label>
+                    <div class="input-container">
+                        <input
+                            type="password"
+                            id="newPassword"
+                            v-model="newPassword"
+                            class="form-input"
+                            placeholder="새 비밀번호"
+                            required
+                        />
+                        <div class="input-focus-indicator"></div>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="confirmPassword">비밀번호 확인</label>
+                    <div class="input-container">
+                        <input
+                            type="password"
+                            id="confirmPassword"
+                            v-model="confirmPassword"
+                            class="form-input"
+                            placeholder="비밀번호 확인"
+                            required
+                        />
+                        <div class="input-focus-indicator"></div>
+                    </div>
+                </div>
+
+                <div class="button-group">
+                    <button type="submit" class="btn btn-save">
+                        <span class="btn-text">저장</span>
+                    </button>
+                    <button
+                        type="button"
+                        class="btn btn-cancel"
+                        @click="cancel"
+                    >
+                        <span class="btn-text">취소</span>
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import axios from "axios";
+import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/auth";
+
+const router = useRouter();
+const authStore = useAuthStore();
+
+const newPassword = ref("");
+const confirmPassword = ref("");
+
+const changePassword = async () => {
+    if (newPassword.value !== confirmPassword.value) {
+        alert("비밀번호가 일치하지 않습니다.");
+        return;
+    }
+
+    try {
+        await axios.patch(
+            "http://localhost:8080/me/password",
+            { password: newPassword.value },
+            {
+                headers: {
+                    Authorization: `Bearer ${authStore.accessToken}`,
+                    "Content-Type": "application/json",
+                },
+            }
+        );
+        alert("비밀번호가 변경되었습니다.");
+        router.push("/mypage");
+    } catch (error) {
+        console.error("비밀번호 변경 실패:", error);
+        alert("비밀번호 변경 중 오류가 발생했습니다.");
+    }
+};
+
+const cancel = () => {
+    if (newPassword.value || confirmPassword.value) {
+        if (
+            confirm(
+                "변경 사항이 저장되지 않을 수 있습니다. 정말로 취소하시겠습니까?"
+            )
+        ) {
+            router.push("/mypage");
+        }
+    } else {
+        router.push("/mypage");
+    }
+};
+</script>
+
+<style scoped>
+/* 기존 스타일 파일에서 .edit-profile-page 클래스를 .edit-password-page로 바꾸고 그대로 복사하면 됨 */
+.edit-password-page {
+    width: 100%;
+    min-height: 80vh;
+    background-color: #ffffff;
+    font-family: "Noto Sans KR", Arial, sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    overflow-x: hidden;
+}
+
+.content {
+    width: 100%;
+    max-width: 800px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px 40px 60px;
+    position: relative;
+    margin-top: 50px;
+}
+
+.page-title {
+    color: #6aaad9;
+    font-size: 28px;
+    text-align: center;
+    margin-bottom: 40px;
+    font-weight: 600;
+    position: relative;
+}
+
+.edit-form {
+    width: 100%;
+    max-width: 650px;
+}
+
+.form-group {
+    display: flex;
+    margin-bottom: 28px;
+    align-items: center;
+}
+
+.form-group label {
+    width: 120px;
+    font-size: 18px;
+    color: #333333;
+    text-align: left;
+    font-weight: 500;
+}
+
+.input-container {
+    flex: 1;
+    position: relative;
+}
+
+.form-input {
+    width: 100%;
+    height: 52px;
+    padding: 0 16px;
+    border: 2px solid #e0e0e0;
+    border-radius: 8px;
+    background-color: #f8f9fa;
+    font-size: 18px;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: #7eb9e6;
+    background-color: #ffffff;
+    box-shadow: 0 0 0 4px rgba(126, 185, 230, 0.15);
+}
+
+.input-focus-indicator {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background-color: #7eb9e6;
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.3s ease;
+    border-radius: 1px;
+}
+
+.button-group {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    margin-top: 50px;
+    width: 100%;
+}
+
+.btn {
+    position: relative;
+    width: 200px;
+    height: 52px;
+    border-radius: 8px;
+    font-size: 18px;
+    font-weight: 500;
+    cursor: pointer;
+    border: none;
+    transition: all 0.3s ease;
+    overflow: hidden;
+}
+
+.btn-save {
+    background-color: #7eb9e6;
+    color: white;
+}
+
+.btn-cancel {
+    background-color: #f0f0f0;
+    color: #666666;
+}
+</style>

--- a/src/views/auth/EditProfilePage.vue
+++ b/src/views/auth/EditProfilePage.vue
@@ -17,7 +17,12 @@
             <div class="profile-image-section">
                 <div class="profile-image">
                     <div class="profile-circle">
-                        <img v-if="previewImage" :src="previewImage" alt="Profile Preview" class="preview-image" />
+                        <img
+                            v-if="previewImage"
+                            :src="previewImage"
+                            alt="Profile Preview"
+                            class="preview-image"
+                        />
                     </div>
                     <label for="profile-input" class="camera-button">
                         <span class="camera-icon"></span>
@@ -49,11 +54,24 @@
                     </div>
                 </div>
 
-                <!-- 칭호호 필드 -->
+                <!-- 칭호 필드 -->
                 <div class="form-group">
                     <label for="title">칭호</label>
                     <div class="input-container">
-                        <input type="text" id="title" v-model="userInfo.title" class="form-input" placeholder="칭호" />
+                        <select
+                            id="title"
+                            v-model="userInfo.titleId"
+                            class="form-input"
+                        >
+                            <option disabled value="">칭호를 선택하세요</option>
+                            <option
+                                v-for="title in titleList"
+                                :key="title.titleId"
+                                :value="title.titleId"
+                            >
+                                {{ title.name }}
+                            </option>
+                        </select>
                         <div class="input-focus-indicator"></div>
                     </div>
                 </div>
@@ -78,7 +96,11 @@
                     <button type="submit" class="btn btn-save">
                         <span class="btn-text">저장</span>
                     </button>
-                    <button type="button" class="btn btn-cancel" @click="cancel">
+                    <button
+                        type="button"
+                        class="btn btn-cancel"
+                        @click="cancel"
+                    >
                         <span class="btn-text">취소</span>
                     </button>
                 </div>
@@ -88,20 +110,42 @@
 </template>
 
 <script>
+import axios from "axios";
+
 export default {
     name: "EditProfilePage",
     data() {
         return {
             userInfo: {
                 nickname: "",
-                title: "",
+                titleId: "", // 🔄 title이 아니라 titleId로 바꿈
                 referralCode: "",
                 profileImage: null,
             },
             previewImage: null,
+            titleList: [], // [{ titleId: 3, name: '여행의 시작', ... }, ...]
         };
     },
+    mounted() {
+        this.fetchTitles(); // 🔥 페이지 진입 시 호출
+    },
     methods: {
+        fetchTitles() {
+            axios
+                .get("http://localhost:8080/title", {
+                    headers: {
+                        Authorization: `Bearer ${localStorage.getItem(
+                            "accessToken"
+                        )}`,
+                    },
+                })
+                .then((res) => {
+                    this.titleList = res.data; // 예: ['용감한 모험가', '탐험가', '지식왕']
+                })
+                .catch((err) => {
+                    console.error("칭호 목록 불러오기 실패:", err);
+                });
+        },
         onFileSelected(event) {
             const file = event.target.files[0];
             if (file) {
@@ -117,39 +161,33 @@ export default {
             reader.readAsDataURL(file);
         },
         saveProfile() {
-            // 프로필 저장 로직
             console.log("프로필 저장:", this.userInfo);
 
-            // FormData를 사용하여 이미지 업로드 처리
             const formData = new FormData();
             formData.append("nickname", this.userInfo.nickname);
-            formData.append("title", this.userInfo.title);
+            formData.append("titleId", this.userInfo.titleId);
             formData.append("referralCode", this.userInfo.referralCode);
             if (this.userInfo.profileImage) {
                 formData.append("profileImage", this.userInfo.profileImage);
             }
 
-            // API 호출 예시
-            // this.$http.post('/api/user/profile', formData)
-            //   .then(response => {
-            //     this.$router.push('/mypage');
-            //   })
-            //   .catch(error => {
-            //     console.error('프로필 저장 중 오류 발생:', error);
-            //   });
+            // 실제 저장 API 호출은 아래 주석 참고
+            // axios.post('/api/user/profile', formData).then(...)
 
-            // 임시로 페이지 이동
             this.$router.push("/mypage");
         },
         cancel() {
-            // 변경 사항이 있는지 확인
             if (
                 this.userInfo.nickname ||
                 this.userInfo.title ||
                 this.userInfo.referralCode ||
                 this.userInfo.profileImage
             ) {
-                if (confirm("변경 사항이 저장되지 않을 수 있습니다. 정말로 취소하시겠습니까?")) {
+                if (
+                    confirm(
+                        "변경 사항이 저장되지 않을 수 있습니다. 정말로 취소하시겠습니까?"
+                    )
+                ) {
                     this.$router.push("/mypage");
                 }
             } else {
@@ -243,7 +281,11 @@ export default {
     left: 0;
     width: 100%;
     height: 100%;
-    background: linear-gradient(180deg, rgba(240, 249, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
+    background: linear-gradient(
+        180deg,
+        rgba(240, 249, 255, 0.2) 0%,
+        rgba(255, 255, 255, 0) 100%
+    );
     pointer-events: none;
     z-index: -1;
 }

--- a/src/views/auth/EditProfilePage.vue
+++ b/src/views/auth/EditProfilePage.vue
@@ -80,13 +80,15 @@
                 <div class="form-group">
                     <label for="referralCode">추천 모드</label>
                     <div class="input-container">
-                        <input
-                            type="text"
+                        <select
                             id="referralCode"
                             v-model="userInfo.referralCode"
                             class="form-input"
-                            placeholder="추천 모드"
-                        />
+                        >
+                            <option disabled value="">모드를 선택하세요</option>
+                            <option :value="0">일상 모드</option>
+                            <option :value="1">여행 모드</option>
+                        </select>
                         <div class="input-focus-indicator"></div>
                     </div>
                 </div>
@@ -118,16 +120,16 @@ export default {
         return {
             userInfo: {
                 nickname: "",
-                titleId: "", // 🔄 title이 아니라 titleId로 바꿈
-                referralCode: "",
+                titleId: "",
+                referralCode: "", // 문자열 "" → 숫자 0 또는 1로 바뀌므로 주의
                 profileImage: null,
             },
             previewImage: null,
-            titleList: [], // [{ titleId: 3, name: '여행의 시작', ... }, ...]
+            titleList: [],
         };
     },
     mounted() {
-        this.fetchTitles(); // 🔥 페이지 진입 시 호출
+        this.fetchTitles();
     },
     methods: {
         fetchTitles() {
@@ -140,7 +142,7 @@ export default {
                     },
                 })
                 .then((res) => {
-                    this.titleList = res.data; // 예: ['용감한 모험가', '탐험가', '지식왕']
+                    this.titleList = res.data;
                 })
                 .catch((err) => {
                     console.error("칭호 목록 불러오기 실패:", err);
@@ -166,14 +168,10 @@ export default {
             const formData = new FormData();
             formData.append("nickname", this.userInfo.nickname);
             formData.append("titleId", this.userInfo.titleId);
-            formData.append("referralCode", this.userInfo.referralCode);
+            formData.append("referralCode", Number(this.userInfo.referralCode));
             if (this.userInfo.profileImage) {
                 formData.append("profileImage", this.userInfo.profileImage);
             }
-
-            // 실제 저장 API 호출은 아래 주석 참고
-            // axios.post('/api/user/profile', formData).then(...)
-
             this.$router.push("/mypage");
         },
         cancel() {

--- a/src/views/auth/MypagePage.vue
+++ b/src/views/auth/MypagePage.vue
@@ -110,9 +110,25 @@ const changePassword = () => {
     router.push("/change-password");
 };
 
-const withdrawAccount = () => {
+const withdrawAccount = async () => {
     if (confirm("정말로 탈퇴하시겠습니까?")) {
-        // 탈퇴 API 연결 예정
+        try {
+            await axios.patch("http://localhost:8080/me/withdraw", null, {
+                headers: {
+                    Authorization: `Bearer ${authStore.accessToken}`,
+                },
+            });
+
+            console.log("요청 보냄ㅠㅠ");
+
+            // 토큰 제거 및 로그아웃 처리
+            authStore.clearTokens();
+            alert("정상적으로 탈퇴되었습니다.");
+            router.push("/login");
+        } catch (error) {
+            console.error("회원 탈퇴 실패:", error);
+            alert("탈퇴 처리 중 오류가 발생했습니다.");
+        }
     }
 };
 

--- a/src/views/auth/MypagePage.vue
+++ b/src/views/auth/MypagePage.vue
@@ -107,7 +107,7 @@ const editUserInfo = () => {
 };
 
 const changePassword = () => {
-    router.push("/change-password");
+    router.push("/edit-password");
 };
 
 const withdrawAccount = async () => {
@@ -119,9 +119,6 @@ const withdrawAccount = async () => {
                 },
             });
 
-            console.log("요청 보냄ㅠㅠ");
-
-            // 토큰 제거 및 로그아웃 처리
             authStore.clearTokens();
             alert("정상적으로 탈퇴되었습니다.");
             router.push("/login");


### PR DESCRIPTION
## 관련 이슈
- resolves: #35 

## 작업 내용
- 내 정보 조회 기능 연결
- nickname, title, mode 정보 수정 기능 연결
- 비밀번호 변경 페이지 추가
- password 정보 수정 기능 연결
- 회원 탈퇴 기능 연결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 비밀번호 변경 페이지가 추가되어 사용자가 비밀번호를 직접 변경할 수 있습니다.

- **버그 수정**
  - 마이페이지 네비게이션 링크가 "/profile"에서 "/myPage"로 변경되었습니다.

- **리팩터링**
  - 마이페이지 및 프로필 수정 페이지가 Composition API와 동적 데이터 연동 방식으로 개선되었습니다.
  - 프로필 수정 시 이미지 업로드 기능이 제거되고, 타이틀과 추천 코드는 드롭다운 선택 방식으로 변경되었습니다.

- **사용성 개선**
  - 마이페이지에서 실제 사용자 정보가 백엔드에서 불러와져 표시됩니다.
  - 계정 탈퇴, 비밀번호 변경 등 주요 기능의 안내 및 오류 처리 메시지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->