### PR TITLE
[FEAT] #73 - 메인페이지 추천 퀘스트 리스트 화면 구현

### DIFF
--- a/src/components/main/PopularRoutes.vue
+++ b/src/components/main/PopularRoutes.vue
@@ -145,8 +145,8 @@ onMounted(() => {
 
 <style scoped>
 .section {
-    margin-bottom: 32px;
-    padding: 0 8px;
+    margin-bottom: 2rem;
+    padding: 0 0.5rem;
 }
 
 /* 카드 스타일 */
@@ -155,14 +155,15 @@ onMounted(() => {
     display: flex;
     flex-direction: column;
     background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
-    padding: 20px;
-    border-radius: 16px;
-    border: 1px solid #e3e8ef;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.04);
+    padding: 1.25rem;
+    border-radius: 1rem;
+    border: 0.0625rem solid #e3e8ef;
+    box-shadow: 0 0.25rem 1.25rem rgba(0, 0, 0, 0.08), 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.04);
     transition: all 0.3s ease;
     position: relative;
     overflow: hidden;
-    min-height: 320px;
+    min-height: 20rem;
+    margin: 0 0.25rem; /* 카드 사이 여백 추가 */
 }
 
 .card::before {
@@ -171,14 +172,14 @@ onMounted(() => {
     top: 0;
     left: 0;
     right: 0;
-    height: 4px;
+    height: 0.25rem;
     background: linear-gradient(90deg, #7db4d5 0%, #5da0c4 50%, #4a90e2 100%);
-    border-radius: 16px 16px 0 0;
+    border-radius: 1rem 1rem 0 0;
 }
 
 .card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12), 0 4px 12px rgba(0, 0, 0, 0.06);
+    transform: translateY(-0.25rem);
+    box-shadow: 0 0.5rem 1.875rem rgba(0, 0, 0, 0.12), 0 0.25rem 0.75rem rgba(0, 0, 0, 0.06);
 }
 
 /* 카드 컨텐츠 */
@@ -186,18 +187,18 @@ onMounted(() => {
     flex: 1;
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 1rem;
 }
 
 /* 헤더 정보 */
 .plan-header-info {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 0.75rem;
 }
 
 .plan-title {
-    font-size: 18px;
+    font-size: 1.125rem;
     font-weight: 700;
     color: #2c3e50;
     margin: 0;
@@ -211,108 +212,108 @@ onMounted(() => {
 .plan-dates {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 0.5rem;
 }
 
 .date-badge {
     display: inline-flex;
     align-items: center;
-    font-size: 13px;
+    font-size: 0.8125rem;
     font-weight: 600;
     color: #4a90e2;
     background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
-    padding: 6px 12px;
-    border-radius: 20px;
-    border: 1px solid #90caf9;
+    padding: 0.375rem 0.75rem;
+    border-radius: 1.25rem;
+    border: 0.0625rem solid #90caf9;
     width: fit-content;
 }
 
 .duration-info {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 0.375rem;
 }
 
 .duration-badge {
-    font-size: 13px;
+    font-size: 0.8125rem;
     font-weight: 600;
     color: #7b1fa2;
     background: linear-gradient(135deg, #f3e5f5 0%, #e1bee7 100%);
-    padding: 4px 10px;
-    border-radius: 16px;
-    border: 1px solid #ce93d8;
+    padding: 0.25rem 0.625rem;
+    border-radius: 1rem;
+    border: 0.0625rem solid #ce93d8;
 }
 
 /* 메타 정보 */
 .plan-meta {
     display: flex;
-    gap: 16px;
+    gap: 1rem;
 }
 
 .meta-item {
     display: flex;
     align-items: center;
-    gap: 6px;
-    font-size: 14px;
+    gap: 0.375rem;
+    font-size: 0.875rem;
     font-weight: 500;
     color: #546e7a;
     background: #eceff1;
-    padding: 6px 12px;
-    border-radius: 12px;
+    padding: 0.375rem 0.75rem;
+    border-radius: 0.75rem;
 }
 
 .meta-icon {
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 /* 설명 */
 .plan-description {
-    font-size: 14px;
+    font-size: 0.875rem;
     color: #546e7a;
     line-height: 1.5;
     background: #f8f9fa;
-    padding: 12px;
-    border-radius: 12px;
-    border-left: 3px solid #7db4d5;
+    padding: 0.75rem;
+    border-radius: 0.75rem;
+    border-left: 0.1875rem solid #7db4d5;
 }
 
 /* 진행률 섹션 */
 .progress-section {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 0.5rem;
     margin-top: auto;
-    padding-top: 16px;
+    padding-top: 1rem;
 }
 
 .progress-label {
-    font-size: 13px;
+    font-size: 0.8125rem;
     font-weight: 600;
     color: #37474f;
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 0.375rem;
 }
 
 .progress-label::before {
     content: "📊";
-    font-size: 14px;
+    font-size: 0.875rem;
 }
 
 .progress-bar {
     width: 100%;
-    height: 10px;
+    height: 0.625rem;
     background: #e8eaf6;
-    border-radius: 6px;
+    border-radius: 0.375rem;
     overflow: hidden;
     position: relative;
-    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: inset 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.1);
 }
 
 .progress-fill {
     height: 100%;
     background: linear-gradient(90deg, #7db4d5 0%, #5da0c4 50%, #4a90e2 100%);
-    border-radius: 6px;
+    border-radius: 0.375rem;
     transition: width 0.6s ease;
     position: relative;
     overflow: hidden;
@@ -339,30 +340,30 @@ onMounted(() => {
 }
 
 .progress-text {
-    font-size: 12px;
+    font-size: 0.75rem;
     font-weight: 600;
     color: #4a90e2;
     text-align: right;
-    margin-top: 4px;
+    margin-top: 0.25rem;
 }
 
 /* 시작하기 버튼 */
 .start-btn {
-    margin-top: 20px;
+    margin-top: 1.25rem;
     background: linear-gradient(135deg, #7db4d5 0%, #5da0c4 100%);
     color: white;
     border: none;
-    padding: 14px 20px;
-    border-radius: 12px;
-    font-size: 15px;
+    padding: 0.875rem 1.25rem;
+    border-radius: 0.75rem;
+    font-size: 0.9375rem;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.3s ease;
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 8px;
-    box-shadow: 0 4px 12px rgba(125, 180, 213, 0.3);
+    gap: 0.5rem;
+    box-shadow: 0 0.25rem 0.75rem rgba(125, 180, 213, 0.3);
     position: relative;
     overflow: hidden;
 }
@@ -383,8 +384,8 @@ onMounted(() => {
 }
 
 .start-btn:hover:not(:disabled) {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(125, 180, 213, 0.4);
+    transform: translateY(-0.125rem);
+    box-shadow: 0 0.375rem 1.25rem rgba(125, 180, 213, 0.4);
     background: linear-gradient(135deg, #5da0c4 0%, #4a90e2 100%);
 }
 
@@ -400,38 +401,47 @@ onMounted(() => {
 }
 
 .btn-icon {
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 /* Swiper 스타일 */
 ::v-deep(.swiper-horizontal) {
-    padding: 0 16px;
+    padding: 0 1rem;
 }
 
 ::v-deep(.swiper-wrapper) {
-    padding: 16px 0 24px 0;
+    padding: 1rem 0 1.5rem 0;
+}
+
+::v-deep(.swiper-slide) {
+    padding: 0 0.25rem; /* 슬라이드 사이 추가 여백 */
 }
 
 /* 반응형 디자인 */
 @media (max-width: 640px) {
     .card {
-        padding: 16px;
-        min-height: 280px;
+        padding: 1rem;
+        min-height: 17.5rem;
+        margin: 0 0.125rem; /* 모바일에서 카드 여백 줄임 */
     }
 
     .plan-title {
-        font-size: 16px;
+        font-size: 1rem;
     }
 
     .start-btn {
-        padding: 12px 16px;
-        font-size: 14px;
+        padding: 0.75rem 1rem;
+        font-size: 0.875rem;
+    }
+
+    ::v-deep(.swiper-slide) {
+        padding: 0 0.125rem; /* 모바일에서 슬라이드 여백 줄임 */
     }
 }
 
 @media (min-width: 1024px) {
     .card:hover {
-        transform: translateY(-6px) scale(1.02);
+        transform: translateY(-0.375rem) scale(1.02);
     }
 }
 

--- a/src/components/main/QuestList.vue
+++ b/src/components/main/QuestList.vue
@@ -12,13 +12,52 @@
         >
             <SwiperSlide v-for="quest in recommendedQuests" :key="quest.questId">
                 <div class="card">
-                    <img :src="quest.img" alt="관광지 이미지" class="thumbnail" />
-                    <h3>{{ quest.title }}</h3>
-                    <p>{{ quest.difficulty }}</p>
-                    <p>생성일: {{ quest.createdAt.slice(0, 10) }}</p>
-                    <p>참여 인원: {{ quest.participantCount }}명</p>
-                    <p>EXP +{{ quest.exp }} • 스탬프</p>
-                    <button @click="handleStartClick(quest.questId)">시작하기</button>
+                    <div class="card-image">
+                        <!-- <img :src="quest.img" alt="관광지 이미지" class="thumbnail" /> -->
+
+                        <template v-if="quest.img && quest.img !== 'null'">
+                            <img :src="quest.img" alt="관광지 이미지" class="thumbnail" />
+                        </template>
+                        <template v-else>
+                            <img src="@/assets/images/no_attraction_image_available.png" alt="" class="thumbnail" />
+                        </template>
+
+                        <div class="difficulty-badge" :class="getDifficultyClass(quest.difficulty)">
+                            {{ quest.difficulty }}
+                        </div>
+                    </div>
+
+                    <div class="card-content">
+                        <div class="quest-header">
+                            <h3 class="quest-title">{{ quest.title }}</h3>
+                            <div class="quest-meta">
+                                <div class="meta-item">
+                                    <span class="meta-icon">📅</span>
+                                    <span>{{ formatDate(quest.createdAt) }}</span>
+                                </div>
+                                <div class="meta-item">
+                                    <span class="meta-icon">👥</span>
+                                    <span>{{ quest.participantCount }}명</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="reward-section">
+                            <div class="reward-item exp">
+                                <span class="reward-icon">⭐</span>
+                                <span class="reward-text">EXP +{{ quest.exp }}</span>
+                            </div>
+                            <div class="reward-item stamp">
+                                <span class="reward-icon">🏆</span>
+                                <span class="reward-text">스탬프</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <button @click="handleStartClick(quest.questId)" :disabled="loading" class="start-btn">
+                        <span class="btn-icon">🎯</span>
+                        {{ loading ? "시작 중..." : "퀘스트 시작" }}
+                    </button>
                 </div>
             </SwiperSlide>
         </Swiper>
@@ -48,6 +87,25 @@ const fetchRecommendedQuests = async () => {
     }
 };
 
+const formatDate = (dateString) => {
+    if (!dateString) return "";
+    const date = new Date(dateString);
+    return date.toLocaleDateString("ko-KR", {
+        month: "short",
+        day: "numeric",
+    });
+};
+
+const getDifficultyClass = (difficulty) => {
+    const difficultyMap = {
+        EASY: "easy",
+        MEDIUM: "normal",
+        HARD: "hard",
+        VERY_HARD: "very-hard",
+    };
+    return difficultyMap[difficulty] || "normal";
+};
+
 const handleStartClick = (questId) => {
     const token = localStorage.getItem("accessToken");
     if (!token) {
@@ -71,8 +129,6 @@ const handleStartClick = (questId) => {
         .then((response) => {
             alert(response.data.message || "해당 퀘스트가 시작되었습니다.");
             fetchRecommendedQuests();
-            // 상세 페이지로 이동하려면 아래 주석 해제
-            // router.push(`/quests/${questId}`);
         })
         .catch((error) => {
             let errorMessage = "퀘스트 시작 중 오류가 발생했습니다.";
@@ -103,62 +159,297 @@ onMounted(() => {
 
 <style scoped>
 .section {
-    margin-bottom: 20px;
+    margin-bottom: 2rem;
+    padding: 0 0.2rem;
 }
 
+/* 카드 스타일 */
 .card {
-    width: 100%;
+    width: 125%;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-    background: #ffffff;
-    padding: 12px;
-    border-radius: 12px;
-    border: 1px solid #b3b3b3;
-    box-shadow: 6px 7px 8px rgb(0 0 0 / 20%);
+    background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
+    border-radius: 1rem;
+    border: 0.0625rem solid #e3e8ef;
+    box-shadow: 0 0.25rem 1.25rem rgba(0, 0, 0, 0.08), 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.04);
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+    max-height: 25rem;
+    margin: 0 0.25rem;
+}
+
+.card::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 0.25rem;
+    background: linear-gradient(90deg, #ff6b6b 0%, #feca57 50%, #48dbfb 100%);
+    border-radius: 1rem 1rem 0 0;
+}
+
+.card:hover {
+    transform: translateY(-0.25rem);
+    box-shadow: 0 0.5rem 1.875rem rgba(0, 0, 0, 0.12), 0 0.25rem 0.75rem rgba(0, 0, 0, 0.06);
+}
+
+/* 카드 이미지 영역 */
+.card-image {
+    position: relative;
+    overflow: hidden;
 }
 
 .thumbnail {
     width: 100%;
-    height: 140px;
+    height: 9rem;
     object-fit: cover;
-    border-radius: 8px;
-    margin-bottom: 12px;
+    transition: transform 0.3s ease;
 }
 
-.card h3 {
-    font-size: 15px;
+.card:hover .thumbnail {
+    transform: scale(1.05);
+}
+
+.difficulty-badge {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.75rem;
+    font-size: 0.75rem;
     font-weight: 600;
-    margin: 6px 0;
+    backdrop-filter: blur(0.625rem);
+    border: 0.0625rem solid rgba(255, 255, 255, 0.2);
 }
 
-.card p {
-    font-size: 13px;
-    margin: 2px 0;
-    color: #444;
+.difficulty-badge.easy {
+    background: #28a745;
+    color: white;
 }
 
-.card button {
-    margin-top: 10px;
-    background: #7db4d5;
+.difficulty-badge.normal {
+    background: #fd7e14;
+    color: white;
+}
+
+.difficulty-badge.hard {
+    background: #dc3545;
+    color: white;
+}
+
+.difficulty-badge.very-hard {
+    background: rgba(165, 55, 253, 0.9);
+    color: white;
+}
+
+/* 카드 컨텐츠 */
+.card-content {
+    flex: 1;
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.quest-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.quest-title {
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: #2c3e50;
+    margin: 0;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.quest-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: #546e7a;
+    background: #eceff1;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.75rem;
+}
+
+.meta-icon {
+    font-size: 0.875rem;
+}
+
+/* 보상 섹션 */
+.reward-section {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: auto;
+}
+
+.reward-item {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.75rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    flex: 1;
+    justify-content: center;
+}
+
+.reward-item.exp {
+    background: linear-gradient(135deg, #fff3e0 0%, #ffe0b2 100%);
+    color: #f57c00;
+    border: 0.0625rem solid #ffcc02;
+}
+
+.reward-item.stamp {
+    background: linear-gradient(135deg, #e8f5e8 0%, #c8e6c9 100%);
+    color: #388e3c;
+    border: 0.0625rem solid #4caf50;
+}
+
+.reward-icon {
+    font-size: 1rem;
+}
+
+.reward-text {
+    font-size: 0.75rem;
+}
+
+/* 시작 버튼 */
+.start-btn {
+    margin: 0 1.25rem 1.25rem 1.25rem;
+    background: linear-gradient(135deg, #7db4d5 0%, #5da0c4 100%);
     color: white;
     border: none;
-    padding: 8px 12px;
+    padding: 0.875rem 1.25rem;
+    border-radius: 0.75rem;
+    font-size: 0.9375rem;
+    font-weight: 600;
     cursor: pointer;
-    border-radius: 8px;
-    font-size: 14px;
-    transition: background 0.2s ease;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    box-shadow: 0 0.25rem 0.75rem rgba(255, 107, 107, 0.3);
+    position: relative;
+    overflow: hidden;
 }
 
-.card button:hover {
-    background: #5da0c4;
+.start-btn::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+    transition: left 0.5s ease;
 }
 
+.start-btn:hover::before {
+    left: 100%;
+}
+
+.start-btn:hover:not(:disabled) {
+    transform: translateY(-0.125rem);
+    box-shadow: 0 0.375rem 1.25rem rgba(255, 107, 107, 0.4);
+    background: linear-gradient(135deg, #feca57 0%, #48dbfb 100%);
+}
+
+.start-btn:active:not(:disabled) {
+    transform: translateY(0);
+}
+
+.start-btn:disabled {
+    background: linear-gradient(135deg, #bdbdbd 0%, #9e9e9e 100%);
+    cursor: not-allowed;
+    box-shadow: none;
+    transform: none;
+}
+
+.btn-icon {
+    font-size: 1rem;
+}
+
+/* Swiper 스타일 */
 ::v-deep(.swiper-horizontal) {
-    padding: 0 1rem;
+    padding: 0 0.5rem;
 }
 
 ::v-deep(.swiper-wrapper) {
-    padding: 1rem;
+    padding: 1rem 0 1.5rem 0;
+}
+
+::v-deep(.swiper-slide) {
+    padding: 0 0.25rem;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 640px) {
+    .card {
+        min-height: 19rem;
+        margin: 0 0.125rem;
+    }
+
+    .thumbnail {
+        height: 7.5rem;
+    }
+
+    .card-content {
+        padding: 1rem;
+    }
+
+    .quest-title {
+        font-size: 1rem;
+    }
+
+    .start-btn {
+        margin: 0 1rem 1rem 1rem;
+        padding: 0.75rem 1rem;
+        font-size: 0.875rem;
+    }
+
+    ::v-deep(.swiper-slide) {
+        padding: 0 0.125rem;
+    }
+}
+
+@media (min-width: 1024px) {
+    .card:hover {
+        transform: translateY(-0.375rem) scale(1.02);
+    }
+}
+
+/* 로딩 애니메이션 */
+@keyframes pulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}
+
+.start-btn:disabled .btn-icon {
+    animation: pulse 1.5s infinite;
 }
 </style>

--- a/src/components/main/QuestList.vue
+++ b/src/components/main/QuestList.vue
@@ -12,7 +12,7 @@
         >
             <SwiperSlide v-for="quest in recommendedQuests" :key="quest.questId">
                 <div class="card">
-                    <img class="thumbnail" src="@/assets/images/street-bukchon.jpg" alt="썸네일" />
+                    <img :src="quest.img" alt="관광지 이미지" class="thumbnail" />
                     <h3>{{ quest.title }}</h3>
                     <p>{{ quest.difficulty }}</p>
                     <p>생성일: {{ quest.createdAt.slice(0, 10) }}</p>


### PR DESCRIPTION
# 관련 이슈
- resolves: #73 

# 작업 내용
- 메인페이지 추천 퀘스트 리스트 화면 스타일 변경
- 메인 페이지 추천 퀘스트 각각 사진 첨부
- 메인 페이지 여행 경로 px를 rem으로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - PopularRoutes 및 QuestList 컴포넌트의 스타일을 rem 단위로 전환하여 일관성과 반응형 디자인을 개선했습니다.
  - QuestList의 카드 레이아웃, 뱃지, 버튼, 이미지 등 UI 요소의 디자인을 전면적으로 개선했습니다.

- **New Features**
  - 퀘스트 카드에 난이도 뱃지, 보상(EXP/스탬프) 뱃지, 메타데이터(생성일, 참여 인원) 표시가 추가되었습니다.
  - "퀘스트 시작" 버튼에 로딩 상태와 애니메이션 효과가 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->